### PR TITLE
Making two changes to make agent working in Istio (with auth)

### DIFF
--- a/docs/install/deploy.yaml
+++ b/docs/install/deploy.yaml
@@ -181,7 +181,7 @@ metadata:
   namespace: istio-system
 spec:
   hosts:
-  - "mc-agent.istio.io"
+  - "*"
   gateways:
   - mc-gateway
   http:
@@ -193,3 +193,13 @@ spec:
         host: mc-agent.istio-system.svc.cluster.local
         port:
           number: 8999
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+ name: mc-agent
+spec:
+ host: mc-agent.istio-system.svc.cluster.local
+ trafficPolicy:
+   tls:
+     mode: DISABLE


### PR DESCRIPTION
1- Sets the host to "*" for the mc-agent virtual service
2- Adds a new DR to disable tls for mc-agent